### PR TITLE
fix(#26): downgrade @types/node to v24 and lock in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "@types/node"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     open-pull-requests-limit: 10
     ignore:
       - dependency-name: "@types/node"
+        update-types: ["version-update"]
+        versions: [">= 25.0.0"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,12 @@ updates:
     open-pull-requests-limit: 10
     ignore:
       - dependency-name: "@types/node"
-        update-types: ["version-update"]
+        update-types:
+          [
+            "version-update:semver-major",
+            "version-update:semver-minor",
+            "version-update:semver-patch",
+          ]
         versions: [">= 25.0.0"]
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 # [2.1.0](https://github.com/filipo11021/nodejs-password-hashing/compare/v2.0.0...v2.1.0) (2026-01-23)
 
-
 ### Features
 
-* add pepper support to argon2 hashing ([#34](https://github.com/filipo11021/nodejs-password-hashing/issues/34)) ([4d508df](https://github.com/filipo11021/nodejs-password-hashing/commit/4d508dfb97b24f82fb1932f7b0263be42ee357af))
+- add pepper support to argon2 hashing ([#34](https://github.com/filipo11021/nodejs-password-hashing/issues/34)) ([4d508df](https://github.com/filipo11021/nodejs-password-hashing/commit/4d508dfb97b24f82fb1932f7b0263be42ee357af))
 
 # [2.0.0](https://github.com/filipo11021/nodejs-password-hashing/compare/v1.0.2...v2.0.0) (2026-01-21)
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
-    "@types/node": "^25.0.10",
+    "@types/node": "~24.10.9",
     "@types/phc__format": "^1.0.1",
     "lefthook": "^2.0.15",
     "oxlint": "^1.41.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1(semantic-release@25.0.2(typescript@5.9.3))
       '@types/node':
-        specifier: ^25.0.10
-        version: 25.0.10
+        specifier: ~24.10.9
+        version: 24.10.9
       '@types/phc__format':
         specifier: ^1.0.1
         version: 1.0.1
@@ -264,8 +264,8 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
-  '@types/node@25.0.10':
-    resolution: {integrity: sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==}
+  '@types/node@24.10.9':
+    resolution: {integrity: sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -1700,7 +1700,7 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@types/node@25.0.10':
+  '@types/node@24.10.9':
     dependencies:
       undici-types: 7.16.0
 
@@ -1708,7 +1708,7 @@ snapshots:
 
   '@types/phc__format@1.0.1':
     dependencies:
-      '@types/node': 25.0.10
+      '@types/node': 24.10.9
 
   agent-base@7.1.4: {}
 


### PR DESCRIPTION
This PR downgrades @types/node to v24 (LTS) and adds an ignore rule to Dependabot to prevent automated upgrades to non-LTS versions. Closes #26.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Dev deps and automation updates**
> 
> - Downgrades and pins `@types/node` to `~24.10.9` in `package.json`; updates `pnpm-lock.yaml`
> - Adds Dependabot ignore for `@types/node` versions `>= 25.0.0` in `.github/dependabot.yml`
> - Minor formatting fix in `CHANGELOG.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91d9a531770b8d0ae146d4ca379e9061fd42ac4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->